### PR TITLE
アラーム音のON/OFF機能実装・ブラウザタブ上のタイマーバグ等修正 #80

### DIFF
--- a/app/assets/javascripts/timer.js
+++ b/app/assets/javascripts/timer.js
@@ -1,6 +1,6 @@
 document.addEventListener('turbolinks:load', () => {
   let workDuration, shortBreakDuration, longBreakDuration, longBreakCycle;
-  let autoStartWork, autoStartBreak;
+  let autoStartWork, autoStartBreak, alarmOn;
   let currentMinutes, currentSeconds;
   let isWorking = true;
   let timer = null;
@@ -14,140 +14,171 @@ document.addEventListener('turbolinks:load', () => {
   const endButton = document.getElementById('end');
   const alarmSound = document.getElementById('alarm-sound');
 
+  // ポモドーロ設定ページからデータを取得する
   function fetchSettings() {
-      return fetch('/pomodoro_settings/show')
-          .then(response => {
-              if (response.status === 401 || response.status === 404) {
-                  return fetch('/default_pomodoro_settings');
-              }
-              return response;
-          })
-          .then(response => response.json())
-          .then(data => {
-              workDuration = data.work_duration;
-              shortBreakDuration = data.short_break_duration;
-              longBreakDuration = data.long_break_duration;
-              longBreakCycle = data.long_break_cycle;
-              autoStartWork = data.auto_start_work;
-              autoStartBreak = data.auto_start_break;
-              currentMinutes = workDuration;
-              currentSeconds = 0;
-              updateTimerDisplay();
-          })
-          .catch(error => {
-              console.error('Error fetching settings:', error);
-              workDuration = 25;
-              shortBreakDuration = 5;
-              longBreakDuration = 15;
-              longBreakCycle = 4;
-              autoStartWork = true;
-              autoStartBreak = true;
-              currentMinutes = workDuration;
-              currentSeconds = 0;
-              updateTimerDisplay();
-          });
+    return fetch('/pomodoro_settings/show')
+      .then(response => { // 未ログインユーザーの場合はデフォルト値を取得
+        if (response.status === 401 || response.status === 404) {
+          return fetch('/default_pomodoro_settings');
+        }
+        return response;
+      })
+      .then(response => response.json())
+      .then(data => {
+        workDuration = data.work_duration;
+        shortBreakDuration = data.short_break_duration;
+        longBreakDuration = data.long_break_duration;
+        longBreakCycle = data.long_break_cycle;
+        autoStartWork = data.auto_start_work;
+        autoStartBreak = data.auto_start_break;
+        alarmOn = data.alarm_on;
+        currentMinutes = workDuration;
+        currentSeconds = 0;
+        updateTimerDisplay();
+      })
+      .catch(error => {
+        console.error('Error fetching settings:', error);
+        workDuration = 25;
+        shortBreakDuration = 5;
+        longBreakDuration = 15;
+        longBreakCycle = 4;
+        autoStartWork = true;
+        autoStartBreak = true;
+        alarmOn = true;
+        currentMinutes = workDuration;
+        currentSeconds = 0;
+        updateTimerDisplay();
+      });
   }
 
+  // ブラウザのタブにタイマーの残り時間を表示する
   function updateTimerDisplay() {
-      const minutes = String(currentMinutes).padStart(2, '0');
-      const seconds = String(currentSeconds).padStart(2, '0');
-      timerElement.textContent = `${minutes}:${seconds}`;
-      if (timer !== null) {
-          document.title = `PomodoroNavi ${minutes}:${seconds}`;
-      }
-  }
+    const minutes = String(currentMinutes).padStart(2, '0');
+    const seconds = String(currentSeconds).padStart(2, '0');
+    timerElement.textContent = `${minutes}:${seconds}`;
 
-  function switchMode() {
-      if (isWorking) {
-          cycleCount++;
-          if (cycleCount % longBreakCycle === 0) {
-              currentMinutes = longBreakDuration;
-              statusElement.textContent = '長い休憩中';
-          } else {
-              currentMinutes = shortBreakDuration;
-              statusElement.textContent = '休憩中';
-          }
-          if (autoStartBreak) {
-              startTimer();
-          } else {
-              stopTimer();
-          }
-      } else {
-          currentMinutes = workDuration;
-          statusElement.textContent = '作業中';
-          if (autoStartWork) {
-              startTimer();
-          } else {
-              stopTimer();
-          }
-      }
-      currentSeconds = 0;
-      isWorking = !isWorking;
-      startTime = new Date();
-      elapsedTime = 0;
-      updateTimerDisplay();
-  }
-
-  function playAlarm() {
-      alarmSound.play();
-  }
-
-  function tick() {
-      const now = new Date();
-      const elapsed = Math.floor((now - startTime) / 1000) + elapsedTime;
-      const totalInitialSeconds = (isWorking ? workDuration : (cycleCount % longBreakCycle === 0 ? longBreakDuration : shortBreakDuration)) * 60;
-      const remainingSeconds = totalInitialSeconds - elapsed;
-
-      if (remainingSeconds <= 0) {
-          playAlarm();
-          switchMode();
-      } else {
-          currentMinutes = Math.floor(remainingSeconds / 60);
-          currentSeconds = remainingSeconds % 60;
-          updateTimerDisplay();
-      }
-  }
-
-  function startTimer() {
-      if (timer === null) {
-          startTime = new Date();
-          timer = setInterval(tick, 1000);
-          startStopButton.textContent = 'Stop';
-          statusElement.textContent = isWorking ? '作業中' : '休憩中';
-      }
-  }
-
-  function stopTimer() {
-      if (timer !== null) {
-          clearInterval(timer);
-          timer = null;
-          elapsedTime += Math.floor((new Date() - startTime) / 1000);
-          startStopButton.textContent = 'Start';
-      }
-  }
-
-  function resetTimer() {
-      stopTimer();
-      currentMinutes = workDuration;
-      currentSeconds = 0;
-      isWorking = true;
-      cycleCount = 0;
-      elapsedTime = 0;
-      statusElement.textContent = '';
-      updateTimerDisplay();
+    // タイマー動作中のみタイトル更新
+    if (timer !== null) {
+      document.title = `PomodoroNavi ${minutes}:${seconds}`;
+    } else {
       document.title = 'PomodoroNavi';
+    }
   }
 
-  startStopButton.addEventListener('click', () => {
-      if (timer === null) {
-          startTimer();
+  // タイマーのモード（「作業中」「休憩中」「長い休憩中」）を切り替える
+  function switchMode() {
+    if (isWorking) {
+      cycleCount++;
+      if (cycleCount % longBreakCycle === 0) {
+        currentMinutes = longBreakDuration;
+        statusElement.textContent = '長い休憩中';
       } else {
-          stopTimer();
+        currentMinutes = shortBreakDuration;
+        statusElement.textContent = '休憩中';
       }
+      if (autoStartBreak) {
+        startTimer();
+      } else {
+        stopTimer();
+      }
+    } else {
+      currentMinutes = workDuration;
+      statusElement.textContent = '作業中';
+      if (autoStartWork) {
+        startTimer();
+      } else {
+        stopTimer();
+      }
+    }
+    currentSeconds = 0;
+    isWorking = !isWorking;
+    startTime = new Date();
+    elapsedTime = 0;
+    updateTimerDisplay();
+  }
+
+  // アラーム音を再生する
+  function playAlarm() {
+    if (alarmOn) {
+      alarmSound.play();
+    }
+  }
+
+  // タイマーのカウントダウン処理
+  function tick() {
+    const now = new Date();
+    const elapsed = Math.floor((now - startTime) / 1000) + elapsedTime;
+    const totalInitialSeconds = (isWorking ? workDuration : (cycleCount % longBreakCycle === 0 ? longBreakDuration : shortBreakDuration)) * 60;
+    const remainingSeconds = totalInitialSeconds - elapsed;
+
+    if (remainingSeconds <= 0) {
+      playAlarm();
+      switchMode();
+    } else {
+      currentMinutes = Math.floor(remainingSeconds / 60);
+      currentSeconds = remainingSeconds % 60;
+      updateTimerDisplay();
+    }
+  }
+
+  // タイマーの開始処理
+  function startTimer() {
+    if (timer === null) {
+      startTime = new Date();
+      timer = setInterval(tick, 1000);
+      startStopButton.textContent = 'Stop';
+
+      // 長い休憩中、通常休憩中、作業中を正確に表示
+      if (!isWorking && cycleCount % longBreakCycle === 0) {
+        statusElement.textContent = '長い休憩中';
+      } else {
+        statusElement.textContent = isWorking ? '作業中' : '休憩中';
+      }
+    }
+  }
+
+  // タイマーの停止処理
+  function stopTimer() {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+      elapsedTime += Math.floor((new Date() - startTime) / 1000);
+      startStopButton.textContent = 'Start';
+      document.title = 'PomodoroNavi';
+    }
+  }
+
+  // タイマーのリセット処理
+  function resetTimer() {
+    stopTimer();
+    currentMinutes = workDuration;
+    currentSeconds = 0;
+    isWorking = true;
+    cycleCount = 0;
+    elapsedTime = 0;
+    statusElement.textContent = '';
+    updateTimerDisplay();
+    document.title = 'PomodoroNavi';
+  }
+
+  // ボタンクリック時の処理
+  startStopButton.addEventListener('click', () => {
+    if (timer === null) {
+      startTimer();
+    } else {
+      stopTimer();
+    }
   });
 
   endButton.addEventListener('click', () => {
-      resetTimer();
+    resetTimer();
+  });
+
+  // ページ遷移時にタイマーをクリア
+  document.addEventListener('turbolinks:before-cache', () => {
+    if (timer !== null) {
+      clearInterval(timer);
+    }
   });
 
   fetchSettings();

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_pomodoro_settings
+  before_action :set_navi_character
 
   def configure_permitted_parameters
     # 新規登録時にnameというキーのパラメーターを追加で許可する
@@ -16,5 +17,10 @@ class ApplicationController < ActionController::Base
   # ユーザーのポモドーロタイマー設定を取得する
   def set_pomodoro_settings
     @pomodoro_settings = current_user&.pomodoro_setting || PomodoroSetting.default
+  end
+
+  # ユーザーのナビキャラクターを取得する
+  def set_navi_character
+    @navi_character = current_user&.navi_character || NaviCharacter.default
   end
 end

--- a/app/controllers/navi_characters_controller.rb
+++ b/app/controllers/navi_characters_controller.rb
@@ -31,7 +31,7 @@ class NaviCharactersController < ApplicationController
   private
 
   def set_navi_character
-    @navi_character = current_user.navi_characters.first || NaviCharacter.default
+    @navi_character = current_user.navi_character || NaviCharacter.default
   end
 
   def navi_character_params

--- a/app/controllers/openai_navis_controller.rb
+++ b/app/controllers/openai_navis_controller.rb
@@ -22,7 +22,7 @@ class OpenaiNavisController < ApplicationController
   end
 
   def set_navi_character
-    @navi_character = current_user&.navi_characters&.first || NaviCharacter.default
+    @navi_character = current_user&.navi_character || NaviCharacter.default
   end
 
   def get_openai_response(user_input, navi_character, user)

--- a/app/controllers/pomodoro_settings_controller.rb
+++ b/app/controllers/pomodoro_settings_controller.rb
@@ -17,13 +17,17 @@ class PomodoroSettingsController < ApplicationController
   end
 
   def show
-    @pomodoro_settings = current_user.pomodoro_setting || PomodoroSetting.default
-    render json: @pomodoro_settings
+    if current_user
+      @pomodoro_settings = current_user.pomodoro_setting || PomodoroSetting.default
+      render json: @pomodoro_settings
+    else
+      show_default
+    end
   end
 
   # デフォルトのポモドーロタイマー設定を参照するメソッド（未ログインユーザー用）
   def show_default
-    @pomodoro_settings = PomodoroSetting.default
+    @pomodoro_settings = PomodoroSetting.find_by(user_id: nil)
     render json: @pomodoro_settings
   end
 

--- a/app/controllers/staticpages_controller.rb
+++ b/app/controllers/staticpages_controller.rb
@@ -9,7 +9,7 @@ class StaticpagesController < ApplicationController
 
   def set_navi_character
     @navi_character = if current_user
-                        current_user.navi_characters.first || NaviCharacter.default
+                        current_user.navi_character || NaviCharacter.default
                       else
                         NaviCharacter.default
                       end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -52,4 +52,11 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # def after_omniauth_failure_path_for(scope)
   #   super(scope)
   # end
+
+  private
+
+  # ナビキャラクターが登録されているかどうかを判定するメソッド
+  def navi_character_registered?
+    NaviCharacter.exists?(user_id: current_user.id)
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -82,6 +82,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   private
 
   def set_navi_character
-    @navi_character = current_user.navi_characters.first
+    @navi_character = current_user.navi_character
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[google_oauth2]
-  has_many :navi_characters
+  # ユーザーは1つのナビキャラクターを持つ
+  has_one :navi_character
+  # ユーザーは1つのポモドーロタイマー設定を持つ
   has_one :pomodoro_setting
 
   validates :name, presence: true, length: { maximum: 20 }
@@ -19,8 +21,8 @@ class User < ApplicationRecord
     end
   end
 
-  #ナビキャラクターが登録されているかどうかを判定するメソッド
+  # ナビキャラクターが登録されているかどうかを判定するメソッド
   def navi_character_registered?
-    navi_characters.exists?
+    navi_character.present?
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,8 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload', type: "module" %>
+    <%= javascript_include_tag 'timer', 'data-turbolinks-track': 'reload', type: "module" %>
+    <%= javascript_include_tag 'navi', 'data-turbolinks-track': 'reload', type: "module" %>
   </head>
 
   <body style="background-color: <%= @pomodoro_settings&.background_color %>;">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -4,6 +4,6 @@
       <% end %>
     </div>
     <div class="header-right">
-        <%= link_to "Login", new_user_session_path %>
-        <%= link_to "Signup", new_user_registration_path %>
+        <%= link_to "Login", new_user_session_path, data: { turbo: false }  %>
+        <%= link_to "Signup", new_user_registration_path, data: { turbo: false }  %>
     </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <div class="footer-links">
-    <%= link_to '利用規約', page_path('TermsOfService') %>
-    <%= link_to 'プライバシーポリシー', page_path('PrivacyPolicy') %>
+    <%= link_to '利用規約', page_path('TermsOfService'), data: { turbo: false }  %>
+    <%= link_to 'プライバシーポリシー', page_path('PrivacyPolicy'), data: { turbo: false }  %>
     <a href="https://docs.google.com/forms/d/1uHn4xHJzvk-RBYK_RPVxxee345zdIR5JLkxocHoM6Vg/" target="_blank">お問い合わせ</a>
 </div>
 <div class="footer-copyright">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,15 +5,15 @@
 </div>
     <div class="header-right">
       <a href="#"><img src="<%= asset_path 'report.png' %>"></a>
-      <%= link_to edit_pomodoro_settings_path do %>
+      <%= link_to edit_pomodoro_settings_path, data: { turbo: false }  do %>
         <%= image_tag 'comand.png' %>
       <% end %>
     <div class="menu-wrapper">
-      <%= link_to edit_user_registration_path do %>
+      <%= link_to edit_user_registration_path, data: { turbo: false }  do %>
         <%= image_tag 'mypage.png' %>
       <% end %>
       <ul class="menu-list">
-        <li><%= link_to "Profile", edit_user_registration_path %></li>
+        <li><%= link_to "Profile", edit_user_registration_path, data: { turbo: false }  %></li>
         <% if @navi_character.present? && @navi_character.persisted? %>
           <li><%= link_to "Navi", edit_navi_character_path(@navi_character), data: { turbo: false } %></li>
         <% else %>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -7,8 +7,6 @@
     <%= stylesheet_link_tag 'top', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_link_tag 'timer', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_link_tag 'navi_message', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'timer', 'data-turbolinks-track': 'reload', type: "module" %>
-    <%= javascript_include_tag 'navi', 'data-turbolinks-track': 'reload', type: "module" %>
 </head>
 <body>
 <audio id="alarm-sound" src="<%= Rails.env.development? ? '/assets/alarm.mp3' : asset_path('alarm.mp3') %>"></audio>


### PR DESCRIPTION
- ポモドーロタイマーのアラーム音のON/OFF実装
- ページ遷移後もブラウザタブ上のタイマーが停止せずにカウントダウンを続けるバグを修正
- UserとNavi_Characterの関係がhas_many（1対多）になっていたのを、has_one（1対1）に修正したため各ファイルの記述も同様に修正